### PR TITLE
rpmbuilder: fixed conflict with filesystem package in CentOS 7.x.

### DIFF
--- a/rpmbuilder.spec
+++ b/rpmbuilder.spec
@@ -44,7 +44,8 @@ rm -rf %{buildroot}
 %files
 %defattr(-,root,root,-)
 %doc LICENSE.EN LICENSE.RU
-%{_bindir}
+%{_bindir}/%{name}
+%{_bindir}/rpmunbuilder
 
 ###############################################################################
 


### PR DESCRIPTION
`rpmbuilder` can't be installed because of conflict with `filesystem` package in CentOS 7.x. I suggest this patch to fix this issue.