### PR TITLE
Version 1.5.1

### DIFF
--- a/SOURCES/rpmbuilder
+++ b/SOURCES/rpmbuilder
@@ -2904,7 +2904,7 @@ about() {
   show ""
   show "${CL_BL_CYAN}$APP${CL_NORM} ${CL_CYAN}$VER${CL_NORM} - RPM package build helper"
   show ""
-  show "Copyright (C) 2009-2016 ESSENTIAL KAOS" $DARK
+  show "Copyright (C) 2009-$(date +%Y) ESSENTIAL KAOS" $DARK
   show "Essential Kaos Open Source License <https://essentialkaos.com/ekol>" $DARK
   show ""
 }

--- a/SOURCES/rpmbuilder
+++ b/SOURCES/rpmbuilder
@@ -2389,9 +2389,9 @@ scpCommand() {
   ssh_opts=$(getSSHOpts)
 
   if [[ -n "$pass" ]] ; then
-    sshpass -p "$pass" scp $SSH_BASE_OPTS $ssh_opts "$from" "$to"
+    sshpass -p "$pass" scp -q $SSH_BASE_OPTS $ssh_opts "$from" "$to"
   else
-    scp $SSH_BASE_OPTS $ssh_opts "$from" "$to"
+    scp -q $SSH_BASE_OPTS $ssh_opts "$from" "$to"
   fi
 
   return $?
@@ -2475,7 +2475,7 @@ getSSHOpts() {
   local opts
 
   if [[ -n "$key" ]] ; then
-    opts="$opts -i $key"
+    opts="-i $key"
   else
     opts="-o PubkeyAuthentication=no"
   fi

--- a/SOURCES/rpmbuilder
+++ b/SOURCES/rpmbuilder
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 APP="RPMBuilder"
-VER="1.5.0"
+VER="1.5.1"
 
 ####################################################################
 
@@ -198,6 +198,8 @@ main() {
     [[ -n "$dlcache" ]]  && dlcache=$(getAbsPath "$dlcache")
     [[ -n "$download" ]] && dlcache=$(getAbsPath "$download")
 
+    [[ -n "$key" && -r "$HOME/.ssh/$key" ]] && key="$HOME/.ssh/$key"
+
     makeTemp
 
     trap termExit SIGINT
@@ -356,9 +358,11 @@ removeParalellLock() {
 }
 
 checkArgs() {
-  if [[ -n "$key" && ! -r $key ]] ; then
-    show "Can't start build process - key file is not readable." $RED
-    doExit $ERROR_ARGS
+  if [[ -n "$key" ]] ; then
+    if [[ ! -r "$key" && ! -r "$HOME/.ssh/$key" ]] ; then
+      show "Can't start build process - key file is not readable." $RED
+      doExit $ERROR_ARGS
+    fi
   fi
 
   if [[ -n "$parallel" && -z "$remote" ]] ; then

--- a/SOURCES/rpmmacros
+++ b/SOURCES/rpmmacros
@@ -1,5 +1,0 @@
-%_topdir %(echo $HOME)/rpmbuild
-%_smp_mflags -j3
-%__arch_install_post   /usr/lib/rpm/check-rpaths   /usr/lib/rpm/check-buildroot
-%_source_payload w7.xzdio
-%_binary_payload w7.xzdio

--- a/SOURCES/rpmmacros_centos6
+++ b/SOURCES/rpmmacros_centos6
@@ -1,0 +1,18 @@
+########################################################################################
+
+%_topdir             %(echo $HOME)/rpmbuild
+
+# Use all available cores on build node
+%_smp_mflags         -j%(cat /proc/cpuinfo | grep processor | wc -l)
+
+# Disable debug packages
+%debug_package       %{nil}
+
+# Added check-buildroot for post install actions
+%__arch_install_post /usr/lib/rpm/check-rpaths /usr/lib/rpm/check-buildroot
+
+# Use xz compression for payload by default
+%_source_payload w7.xzdio
+%_binary_payload w7.xzdio
+
+########################################################################################

--- a/SOURCES/rpmmacros_centos7
+++ b/SOURCES/rpmmacros_centos7
@@ -1,0 +1,24 @@
+########################################################################################
+
+%_topdir             %(echo $HOME)/rpmbuild
+
+# Use all available cores on build node
+%_smp_mflags         -j%(cat /proc/cpuinfo | grep processor | wc -l)
+
+# Disable debug packages
+%debug_package       %{nil}
+
+# Added check-buildroot for post install actions
+%__arch_install_post /usr/lib/rpm/check-rpaths /usr/lib/rpm/check-buildroot
+
+# Fix broken provides search on CentOS 7
+%_use_internal_dependency_generator 0
+
+# Fix default dist name on CentOS 7
+%dist            .el7
+
+# Use xz compression for payload by default
+%_source_payload w7.xzdio
+%_binary_payload w7.xzdio
+
+########################################################################################

--- a/SOURCES/rpmunbuilder
+++ b/SOURCES/rpmunbuilder
@@ -202,7 +202,7 @@ usage() {
 about() {
   show "${CL_BL_CYAN}$APP${CL_NORM} ${CL_CYAN}$VER${CL_NORM} - Source RPM unbuilder"
   show ""
-  show "Copyright (C) 2009-2016 ESSENTIAL KAOS" $DARK
+  show "Copyright (C) 2009-$(date +%Y) ESSENTIAL KAOS" $DARK
   show "Essential Kaos Open Source License <https://essentialkaos.com/ekol>" $DARK
 }
 

--- a/rpmbuilder.spec
+++ b/rpmbuilder.spec
@@ -2,7 +2,7 @@
 
 Summary:         RPM package build helper
 Name:            rpmbuilder
-Version:         1.5.0
+Version:         1.5.1
 Release:         0%{?dist}
 License:         EKOL
 Group:           Development/Tools
@@ -51,6 +51,10 @@ rm -rf %{buildroot}
 ###############################################################################
 
 %changelog
+* Thu Jan 12 2017 Anton Novojilov <andy@essentialkaos.com> - 1.5.1-0
+- Simplified key definition support
+- Removed scp output in situtation when key-based auth is used
+
 * Mon Dec 26 2016 Anton Novojilov <andy@essentialkaos.com> - 1.5.0-0
 - Git submodules fetching support
 - Download cache usage for sources from VCS's


### PR DESCRIPTION
#### Improvements
* Simplified key definition support (`-i ~/.ssh/some_key = -i some_key`)
* Improved rpmmacros for CentOS6 and CentOS7

#### Bugfixes
* Removed scp output in situtation when key-based auth is used