### PR TITLE
Fix checkPerms function

### DIFF
--- a/SOURCES/rpmunbuilder
+++ b/SOURCES/rpmunbuilder
@@ -150,15 +150,15 @@ checkPerms() {
 
   for perm in $(echo "$perms" | fold -w1) ; do
     case $perm in
-      "R") [[ ! -r "$path" ]] return 1 ;;
-      "W") [[ ! -w "$path" ]] return 1 ;;
-      "E") [[ ! -e "$path" ]] return 1 ;;
-      "D") [[ ! -d "$path" ]] return 1 ;;
-      "F") [[ ! -f "$path" ]] return 1 ;;
-      "S") [[ ! -s "$path" ]] return 1 ;;
-      "H") [[ ! -h "$path" ]] return 1 ;;
-      "X") [[ ! -x "$path" ]] return 1 ;;
-      *) return 1
+      "R") [[ ! -r "$path" ]] && return 1 ;;
+      "W") [[ ! -w "$path" ]] && return 1 ;;
+      "E") [[ ! -e "$path" ]] && return 1 ;;
+      "D") [[ ! -d "$path" ]] && return 1 ;;
+      "F") [[ ! -f "$path" ]] && return 1 ;;
+      "S") [[ ! -s "$path" ]] && return 1 ;;
+      "H") [[ ! -h "$path" ]] && return 1 ;;
+      "X") [[ ! -x "$path" ]] && return 1 ;;
+      *) return 1 ;;
     esac
   done
 


### PR DESCRIPTION
Hi, @andyone.

I found that `rpmunbuilder` utility does not work due to invalid declaration of if-conditional sentence in `checkPerms` function. I decided to fix it on my own and suggest you to merge these changes to upstream.

**Is this ready for review?:** Yes
**Is it a breaking change?:** No