### PR TITLE
Use images from GHCR by default and mark all images on DockerHub as not recommended for usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ sudo make install
 
 #### Using Docker
 
-We provide a big variety of Docker images available on [Docker Hub](http://kaos.sh/d/rpmbuilder) and [GitHub Container Registry](https://kaos.sh/p/rpmbuilder).
+We provide a big variety of Docker images available on [GitHub Container Registry](https://kaos.sh/p/rpmbuilder) and [Docker Hub](http://kaos.sh/d/rpmbuilder).
 
 <details><summary><b>Official images</b></summary><p>
 
@@ -51,10 +51,10 @@ Basic images:
 - `ghcr.io/essentialkaos/rpmbuilder:ol7` (_OracleLinux 7_)
 - `ghcr.io/essentialkaos/rpmbuilder:ol8` (_OracleLinux 8_)
 - `ghcr.io/essentialkaos/rpmbuilder:ol9` (_OracleLinux 9_)
-- `essentialkaos/rpmbuilder:centos7` (_CentOS 7_) **`[Not Recomended]`**
-- `essentialkaos/rpmbuilder:ol7` (_OracleLinux 7_) **`[Not Recomended]`**
-- `essentialkaos/rpmbuilder:ol8` (_OracleLinux 8_) **`[Not Recomended]`**
-- `essentialkaos/rpmbuilder:ol9` (_OracleLinux 9_) **`[Not Recomended]`**
+- `essentialkaos/rpmbuilder:centos7` (_CentOS 7_) **`[Not Recommended]`**
+- `essentialkaos/rpmbuilder:ol7` (_OracleLinux 7_) **`[Not Recommended]`**
+- `essentialkaos/rpmbuilder:ol8` (_OracleLinux 8_) **`[Not Recommended]`**
+- `essentialkaos/rpmbuilder:ol9` (_OracleLinux 9_) **`[Not Recommended]`**
 
 Build node images:
 
@@ -62,10 +62,10 @@ Build node images:
 - `ghcr.io/essentialkaos/rpmbuilder:node-ol7` (_OracleLinux 7_ | Port: `2037`)
 - `ghcr.io/essentialkaos/rpmbuilder:node-ol8` (_OracleLinux 8_ | Port: `2038`)
 - `ghcr.io/essentialkaos/rpmbuilder:node-ol9` (_OracleLinux 9_ | Port: `2039`)
-- `essentialkaos/rpmbuilder:node-centos7` (_CentOS 7_ | Port: `2027`) **`[Not Recomended]`**
-- `essentialkaos/rpmbuilder:node-ol7` (_OracleLinux 7_ | Port: `2037`) **`[Not Recomended]`**
-- `essentialkaos/rpmbuilder:node-ol8` (_OracleLinux 8_ | Port: `2038`) **`[Not Recomended]`**
-- `essentialkaos/rpmbuilder:node-ol9` (_OracleLinux 9_ | Port: `2039`) **`[Not Recomended]`**
+- `essentialkaos/rpmbuilder:node-centos7` (_CentOS 7_ | Port: `2027`) **`[Not Recommended]`**
+- `essentialkaos/rpmbuilder:node-ol7` (_OracleLinux 7_ | Port: `2037`) **`[Not Recommended]`**
+- `essentialkaos/rpmbuilder:node-ol8` (_OracleLinux 8_ | Port: `2038`) **`[Not Recommended]`**
+- `essentialkaos/rpmbuilder:node-ol9` (_OracleLinux 9_ | Port: `2039`) **`[Not Recommended]`**
 
 </p></details>
 

--- a/README.md
+++ b/README.md
@@ -47,25 +47,25 @@ We provide a big variety of Docker images available on [Docker Hub](http://kaos.
 
 Basic images:
 
-- `essentialkaos/rpmbuilder:centos7` (_CentOS 7_)
-- `essentialkaos/rpmbuilder:ol7` (_OracleLinux 7_)
-- `essentialkaos/rpmbuilder:ol8` (_OracleLinux 8_)
-- `essentialkaos/rpmbuilder:ol9` (_OracleLinux 9_)
 - `ghcr.io/essentialkaos/rpmbuilder:centos7` (_CentOS 7_)
 - `ghcr.io/essentialkaos/rpmbuilder:ol7` (_OracleLinux 7_)
 - `ghcr.io/essentialkaos/rpmbuilder:ol8` (_OracleLinux 8_)
 - `ghcr.io/essentialkaos/rpmbuilder:ol9` (_OracleLinux 9_)
+- `essentialkaos/rpmbuilder:centos7` (_CentOS 7_)
+- `essentialkaos/rpmbuilder:ol7` (_OracleLinux 7_)
+- `essentialkaos/rpmbuilder:ol8` (_OracleLinux 8_)
+- `essentialkaos/rpmbuilder:ol9` (_OracleLinux 9_)
 
 Build node images:
 
-- `essentialkaos/rpmbuilder:node-centos7` (_CentOS 7_ | Port: `2027`)
-- `essentialkaos/rpmbuilder:node-ol7` (_OracleLinux 7_ | Port: `2037`)
-- `essentialkaos/rpmbuilder:node-ol8` (_OracleLinux 8_ | Port: `2038`)
-- `essentialkaos/rpmbuilder:node-ol9` (_OracleLinux 9_ | Port: `2039`)
 - `ghcr.io/essentialkaos/rpmbuilder:node-centos7` (_CentOS 7_| Port: `2027`)
 - `ghcr.io/essentialkaos/rpmbuilder:node-ol7` (_OracleLinux 7_ | Port: `2037`)
 - `ghcr.io/essentialkaos/rpmbuilder:node-ol8` (_OracleLinux 8_ | Port: `2038`)
 - `ghcr.io/essentialkaos/rpmbuilder:node-ol9` (_OracleLinux 9_ | Port: `2039`)
+- `essentialkaos/rpmbuilder:node-centos7` (_CentOS 7_ | Port: `2027`)
+- `essentialkaos/rpmbuilder:node-ol7` (_OracleLinux 7_ | Port: `2037`)
+- `essentialkaos/rpmbuilder:node-ol8` (_OracleLinux 8_ | Port: `2038`)
+- `essentialkaos/rpmbuilder:node-ol9` (_OracleLinux 9_ | Port: `2039`)
 
 </p></details>
 

--- a/README.md
+++ b/README.md
@@ -51,21 +51,21 @@ Basic images:
 - `ghcr.io/essentialkaos/rpmbuilder:ol7` (_OracleLinux 7_)
 - `ghcr.io/essentialkaos/rpmbuilder:ol8` (_OracleLinux 8_)
 - `ghcr.io/essentialkaos/rpmbuilder:ol9` (_OracleLinux 9_)
-- `essentialkaos/rpmbuilder:centos7` (_CentOS 7_)
-- `essentialkaos/rpmbuilder:ol7` (_OracleLinux 7_)
-- `essentialkaos/rpmbuilder:ol8` (_OracleLinux 8_)
-- `essentialkaos/rpmbuilder:ol9` (_OracleLinux 9_)
+- `essentialkaos/rpmbuilder:centos7` (_CentOS 7_) **`[Not Recomended]`**
+- `essentialkaos/rpmbuilder:ol7` (_OracleLinux 7_) **`[Not Recomended]`**
+- `essentialkaos/rpmbuilder:ol8` (_OracleLinux 8_) **`[Not Recomended]`**
+- `essentialkaos/rpmbuilder:ol9` (_OracleLinux 9_) **`[Not Recomended]`**
 
 Build node images:
 
-- `ghcr.io/essentialkaos/rpmbuilder:node-centos7` (_CentOS 7_| Port: `2027`)
+- `ghcr.io/essentialkaos/rpmbuilder:node-centos7` (_CentOS 7_ | Port: `2027`)
 - `ghcr.io/essentialkaos/rpmbuilder:node-ol7` (_OracleLinux 7_ | Port: `2037`)
 - `ghcr.io/essentialkaos/rpmbuilder:node-ol8` (_OracleLinux 8_ | Port: `2038`)
 - `ghcr.io/essentialkaos/rpmbuilder:node-ol9` (_OracleLinux 9_ | Port: `2039`)
-- `essentialkaos/rpmbuilder:node-centos7` (_CentOS 7_ | Port: `2027`)
-- `essentialkaos/rpmbuilder:node-ol7` (_OracleLinux 7_ | Port: `2037`)
-- `essentialkaos/rpmbuilder:node-ol8` (_OracleLinux 8_ | Port: `2038`)
-- `essentialkaos/rpmbuilder:node-ol9` (_OracleLinux 9_ | Port: `2039`)
+- `essentialkaos/rpmbuilder:node-centos7` (_CentOS 7_ | Port: `2027`) **`[Not Recomended]`**
+- `essentialkaos/rpmbuilder:node-ol7` (_OracleLinux 7_ | Port: `2037`) **`[Not Recomended]`**
+- `essentialkaos/rpmbuilder:node-ol8` (_OracleLinux 8_ | Port: `2038`) **`[Not Recomended]`**
+- `essentialkaos/rpmbuilder:node-ol9` (_OracleLinux 9_ | Port: `2039`) **`[Not Recomended]`**
 
 </p></details>
 
@@ -78,8 +78,8 @@ chmod +x rpmbuilder-docker
 sudo mv rpmbuilder-docker /usr/bin/
 
 # Pull image
-docker pull essentialkaos/rpmbuilder:ol8
-export IMAGE=essentialkaos/rpmbuilder:ol8
+docker pull ghcr.io/essentialkaos/rpmbuilder:ol8
+export IMAGE=ghcr.io/essentialkaos/rpmbuilder:ol8
 
 # Build package
 cd my-package-dir
@@ -89,8 +89,8 @@ rpmbuilder-docker my-package.spec
 Package build using build node image:
 
 ```bash
-docker pull essentialkaos/rpmbuilder:node-ol8
-docker run -e PUB_KEY="$(cat ~/.ssh/buildnode.pub)" -p 2038:2038 -d essentialkaos/rpmbuilder:node-ol8
+docker pull ghcr.io/essentialkaos/rpmbuilder:node-ol8
+docker run -e PUB_KEY="$(cat ~/.ssh/buildnode.pub)" -p 2038:2038 -d ghcr.io/essentialkaos/rpmbuilder:node-ol8
 
 cd my-package-dir
 rpmbuilder my-package.spec -r builder@localhost:2038 -kk ~/.ssh/buildnode

--- a/rpmbuilder-docker
+++ b/rpmbuilder-docker
@@ -37,7 +37,7 @@ CL_BL_GREY="\e[1;${GREY};49m"
 ################################################################################
 
 # Default image repo
-IMAGE_REPO="essentialkaos/rpmbuilder"
+IMAGE_REPO="ghcr.io/essentialkaos/rpmbuilder"
 
 # Default image name
 DEFAULT_IMAGE="$IMAGE_REPO:ol8"


### PR DESCRIPTION
Docker will sunset Free Team organisations on April 14, 2023 (docker/hub-feedback#2314). We got this email as well. So, I think we have to use our images on GHCR where possible and also, mark all images on DockerHub as not recommended for usage.