### PR TITLE
Version 3.2.0

### DIFF
--- a/.docker/centos7.docker
+++ b/.docker/centos7.docker
@@ -22,7 +22,7 @@ RUN echo "$HOSTNAME" > /etc/hostname && \
     yum -y -q install https://pkgs.kaos.st/kaos-repo-latest.el7.noarch.rpm && \
     yum -y -q install epel-release centos-release-scl && \
     yum -y -q install sudo make which file && \
-    yum -y -q install rpm-build rpmdevtools sshpass epel-rpm-macros && \
+    yum -y -q install rpm-build spec-builddep rpmdevtools sshpass epel-rpm-macros && \
     yum -y -q install perfecto rpmlint pwgen && \
     yum clean all && \
     rm -rf /var/cache/yum /var/log/yum.log && \

--- a/.docker/node-centos7.docker
+++ b/.docker/node-centos7.docker
@@ -26,7 +26,7 @@ RUN echo "$HOSTNAME" > /etc/hostname && \
     yum -y -q install https://pkgs.kaos.st/kaos-repo-latest.el7.noarch.rpm && \
     yum -y -q install epel-release centos-release-scl && \
     yum -y -q install sudo make which file openssh-server openssh-clients && \
-    yum -y -q install rpm-build rpmdevtools epel-rpm-macros && \
+    yum -y -q install rpm-build spec-builddep rpmdevtools epel-rpm-macros && \
     yum -y -q install perfecto rpmlint pwgen && \
     yum clean all && \
     rm -rf /var/cache/yum /var/log/yum.log && \

--- a/.docker/node-ol7.docker
+++ b/.docker/node-ol7.docker
@@ -29,7 +29,7 @@ RUN echo "$HOSTNAME" > /etc/hostname && \
     yum -y -q install https://mirror.yandex.ru/centos/7/extras/x86_64/Packages/centos-release-scl-2-3.el7.centos.noarch.rpm && \
     yum-config-manager --enable ol7_optional_latest >/dev/null 2>&1 /dev/null && \
     yum -y -q install sudo make which file openssh-server openssh-clients && \
-    yum -y -q install rpm-build rpmdevtools epel-rpm-macros && \
+    yum -y -q install rpm-build spec-builddep rpmdevtools epel-rpm-macros && \
     yum -y -q install perfecto rpmlint pwgen && \
     yum clean all && \
     rm -rf /var/cache/yum /var/log/yum.log && \

--- a/.docker/node-ol8.docker
+++ b/.docker/node-ol8.docker
@@ -28,7 +28,7 @@ RUN echo "$HOSTNAME" > /etc/hostname && \
     sed -i 's/gpgcheck=1/gpgcheck=1\nmodule_hotfixes=1/g' /etc/yum.repos.d/epel.repo && \
     dnf config-manager --set-enabled ol8_codeready_builder && \
     dnf -y -q install sudo make which file openssh-server openssh-clients && \
-    dnf -y -q install rpm-build rpmdevtools epel-rpm-macros && \
+    dnf -y -q install rpm-build spec-builddep rpmdevtools epel-rpm-macros && \
     dnf -y -q install perfecto rpmlint pwgen && \
     dnf clean all && \
     rm -rf /var/cache/dnf /var/log/dnf.* && \

--- a/.docker/node-ol9.docker
+++ b/.docker/node-ol9.docker
@@ -28,7 +28,7 @@ RUN echo "$HOSTNAME" > /etc/hostname && \
     sed -i 's/gpgcheck=1/gpgcheck=1\nmodule_hotfixes=1/g' /etc/yum.repos.d/epel.repo && \
     dnf config-manager --set-enabled ol9_codeready_builder && \
     dnf -y -q install sudo make which file openssh-server openssh-clients && \
-    dnf -y -q install rpm-build rpmdevtools epel-rpm-macros && \
+    dnf -y -q install rpm-build spec-builddep rpmdevtools epel-rpm-macros && \
     dnf -y -q install perfecto rpmlint pwgen && \
     dnf clean all && \
     rm -rf /var/cache/dnf /var/log/dnf.* && \

--- a/.docker/ol7.docker
+++ b/.docker/ol7.docker
@@ -25,7 +25,7 @@ RUN echo "$HOSTNAME" > /etc/hostname && \
     yum -y -q install https://mirror.yandex.ru/centos/7/extras/x86_64/Packages/centos-release-scl-2-3.el7.centos.noarch.rpm && \
     yum-config-manager --enable ol7_optional_latest >/dev/null 2>&1 && \
     yum -y -q install sudo make which file && \
-    yum -y -q install rpm-build rpmdevtools sshpass epel-rpm-macros && \
+    yum -y -q install rpm-build spec-builddep rpmdevtools sshpass epel-rpm-macros && \
     yum -y -q install perfecto rpmlint pwgen && \
     yum clean all && \
     rm -rf /var/cache/yum /var/log/yum.log && \

--- a/.docker/ol8.docker
+++ b/.docker/ol8.docker
@@ -24,7 +24,7 @@ RUN echo "$HOSTNAME" > /etc/hostname && \
     sed -i 's/gpgcheck=1/gpgcheck=1\nmodule_hotfixes=1/g' /etc/yum.repos.d/epel.repo && \
     dnf config-manager --set-enabled ol8_codeready_builder && \
     dnf -y -q install sudo make which file && \
-    dnf -y -q install rpm-build rpmdevtools sshpass epel-rpm-macros && \
+    dnf -y -q install rpm-build spec-builddep rpmdevtools sshpass epel-rpm-macros && \
     dnf -y -q install perfecto rpmlint pwgen && \
     dnf clean all && \
     rm -rf /var/cache/dnf /var/log/dnf.* && \

--- a/.docker/ol9.docker
+++ b/.docker/ol9.docker
@@ -24,7 +24,7 @@ RUN echo "$HOSTNAME" > /etc/hostname && \
     sed -i 's/gpgcheck=1/gpgcheck=1\nmodule_hotfixes=1/g' /etc/yum.repos.d/epel.repo && \
     dnf config-manager --set-enabled ol9_codeready_builder && \
     dnf -y -q install sudo make which file && \
-    dnf -y -q install rpm-build rpmdevtools sshpass epel-rpm-macros && \
+    dnf -y -q install rpm-build spec-builddep rpmdevtools sshpass epel-rpm-macros && \
     dnf -y -q install perfecto rpmlint pwgen && \
     dnf clean all && \
     rm -rf /var/cache/dnf /var/log/dnf.* && \

--- a/README.md
+++ b/README.md
@@ -156,11 +156,12 @@ Source packaging:
     rpmbuilder package.spec --git git://github.com/user/project.git -rr f8debbfdbebb97f5d0ee2218edf1425ac219cff5
     rpmbuilder package.spec -bb user:project
     rpmbuilder package.spec --github https://github.com/user/project/
-    rpmbuilder package.spec --gopack github.com/user/project --version v1.2.3
+    rpmbuilder package.spec --gopack github.com/user/project --tag v1.2.3
 
 Dependencies install:
 
-  --install, -I                     Automatically install build dependencies before build process
+  --install, -I                     Install build dependencies before build process
+  --install-latest, -IL             Install the latest versions of build dependencies before build process
   --enable-repo, -ER repo-name      Enable repositories (mergeable)
   --disable-repo, -DR repo-name     Disable repositories (mergeable)
   --exclude-package, -EX package    Exclude package by name or glob (mergeable)
@@ -223,7 +224,7 @@ Other:
   --bump-comment, -bc comment       Comment which will be added while release bump
   --tmp dir                         Path to a temporary directory
   --verbose, -V                     Verbose output
-  --no-color, -C                    Disable colors in output
+  --no-color, -nc                   Disable colors in output
   --help, -h                        Show this help message
   --version, -v                     Show information about version
 ```

--- a/SOURCES/conf/builder.sudoers
+++ b/SOURCES/conf/builder.sudoers
@@ -1,1 +1,1 @@
-builder   ALL=(root)   NOPASSWD:/usr/bin/dnf, /usr/bin/yum, /usr/bin/yum-builddep
+builder   ALL=(root)   NOPASSWD:/usr/bin/dnf, /usr/bin/yum, /usr/bin/spec-builddep

--- a/SOURCES/libexec/build-local.shx
+++ b/SOURCES/libexec/build-local.shx
@@ -30,7 +30,7 @@ localBuild() {
 
   copySourcesToBuildDir "$spec"
 
-  if [[ -n "$install" ]] ; then
+  if [[ -n "$install" || -n "$install_latest" ]] ; then
     showSeparator "DEPENDENCIES INSTALL"
     localDepsInstall "$spec"
   fi

--- a/SOURCES/libexec/build-local.shx
+++ b/SOURCES/libexec/build-local.shx
@@ -99,27 +99,22 @@ copySourcesToBuildDir() {
 localDepsInstall() {
   local spec="$1"
 
-  show "Installing required packages for build…\n"
-
   local yum_opts
   yum_opts=$(getYumOpts "$verbose")
 
+  if [[ -n "$install_latest" ]] ; then
+    yum_opts="$yum_opts --actual"
+  fi
+
   if [[ "$user" == "root" ]] ; then
-    yum $yum_opts clean expire-cache
-    yum-builddep $yum_opts -y "$spec"
+    spec-builddep $yum_opts --clean "$spec"
   else
-    sudo yum $yum_opts clean expire-cache
-    sudo yum-builddep $yum_opts -y "$spec"
+    sudo spec-builddep $yum_opts --clean "$spec"
   fi
 
   if [[ $? -ne 0 ]] ; then
-    show ""
-    error "Can't install required dependencies"
     doExit $ERROR_DEPS
   fi
-
-  show ""
-  show "All required packages installed" $GREEN
 }
 
 # Validate spec on local host

--- a/SOURCES/libexec/build-remote.shx
+++ b/SOURCES/libexec/build-remote.shx
@@ -188,7 +188,7 @@ remoteRunBuild() {
 
   uploadSourcesToRemoteHost "$spec"
 
-  if [[ -n "$install" ]] ; then
+  if [[ -n "$install" || -n "$install_latest" ]] ; then
     showSeparator "DEPENDENCIES INSTALL"
     remoteDepsInstall "$spec"
   fi

--- a/SOURCES/libexec/build-remote.shx
+++ b/SOURCES/libexec/build-remote.shx
@@ -242,20 +242,17 @@ remoteDepsInstall() {
   rpmbuild_dir=$(getRPMBuildDir)
   specs_dir="$rpmbuild_dir/SPECS"
 
-  show "Installing required packages for build…\n"
-
   yum_opts=$(getYumOpts "$verbose")
 
-  sshCommand "$host" "sudo yum $yum_opts clean expire-cache && cd $specs_dir && sudo yum-builddep $yum_opts -y $spec_name"
-
-  if [[ $? -ne 0 ]] ; then
-    show ""
-    error "Can't install required dependencies"
-    doExit $ERROR_DEPS
+  if [[ -n "$install_latest" ]] ; then
+    yum_opts="$yum_opts --actual"
   fi
 
-  show ""
-  show "All required packages installed" $GREEN
+  sshCommand "$host" "cd $specs_dir && sudo spec-builddep --clean $yum_opts $spec_name"
+
+  if [[ $? -ne 0 ]] ; then
+    doExit $ERROR_DEPS
+  fi
 }
 
 # Validates spec on remote host

--- a/SOURCES/rpmbuilder
+++ b/SOURCES/rpmbuilder
@@ -13,7 +13,7 @@ fi
 APP="RPMBuilder"
 
 # Utility version (String)
-VER="3.1.1"
+VER="3.2.0"
 
 # Utility description (String)
 DESC="RPM package build helper"
@@ -86,7 +86,7 @@ SUPPORTED_OPTS="remote !parallel key source_dir source_list !sign !no_build
  !install github node bitbucket launchpad with without define output !verbose 
  !help !version !raw_version qa_rpaths tmux_worker !no_color !keep_log !notify 
  arch download !relative_pack enable_repo disable_repo exclude_package gopack 
- !no_validate !strict !pedantic !perfect"
+ !no_validate !strict !pedantic !perfect !install_latest"
 
 SHORT_OPTS="r:remote P:!parallel k:key sd:source_dir sl:source_list 
  NB:!no_build NC:!no_clean ND:!no_deps NR:!no_binary NS:!no_source p:pack 
@@ -95,7 +95,8 @@ SHORT_OPTS="r:remote P:!parallel k:key sd:source_dir sl:source_list
  rt:tag rr:revision gh:github bb:bitbucket lp:launchpad w:with W:without 
  s:!sign D:define O:output V:!verbose h:help v:!version nv:!no_validate 
  nc:!no_color kl:!keep_log n:!notify a:arch dl:download R:relative_pack 
- ER:enable_repo DR:disable_repo EX:exclude_package G:gopack A:!attach N:node"
+ ER:enable_repo DR:disable_repo EX:exclude_package G:gopack A:!attach N:node 
+ IL:!install_latest"
 
 INSPEC_OPTS="git svn hg bzr branch revision tag svn_user svn_pass github 
  bitbucket launchpad qa_rpaths no_lint no_validate relative_pack gopack strict 
@@ -472,7 +473,8 @@ usage() {
   show ""
   show "Dependencies install:" $BOLD
   show ""
-  showo "--install, -I" "Automatically install build dependencies before build process"
+  showo "--install, -I" "Install build dependencies before build process"
+  showo "--install-latest, -IL" "Install the latest versions of build dependencies before build process"
   showo "--enable-repo, -ER" "Enable repositories ${CL_DARK}(mergeable)${CL_NORM}" "repo-name"
   showo "--disable-repo, -DR" "Disable repositories ${CL_DARK}(mergeable)${CL_NORM}" "repo-name"
   showo "--exclude-package, -EX" "Exclude package by name or glob ${CL_DARK}(mergeable)${CL_NORM}" "package"

--- a/SOURCES/rpmbuilder
+++ b/SOURCES/rpmbuilder
@@ -553,6 +553,7 @@ about() {
   rpm_ver=$(rpm -q rpm --queryformat '%{version}' 2>/dev/null | grep -v 'installed')
   rpml_ver=$(rpm -q rpmlint --queryformat '%{version}' 2>/dev/null | grep -v 'installed')
   perf_ver=$(rpm -q perfecto --queryformat '%{version}' 2>/dev/null | grep -v 'installed')
+  sbd_ver=$(rpm -q spec-builddep --queryformat '%{version}' 2>/dev/null | grep -v 'installed')
 
   show ""
   if [[ -f "/.dockerenv" ]] ; then
@@ -564,7 +565,8 @@ about() {
     show "│" $DARK
     show "├ rpm: ${rpm_ver:-—}" $DARK
     show "├ rpmlint: ${rpml_ver:-—}" $DARK
-    show "└ perfecto: ${perf_ver:-—}" $DARK
+    show "├ perfecto: ${perf_ver:-—}" $DARK
+    show "└ spec-builddep: ${sbd_ver:-—}" $DARK
   fi
   show ""
   show "Copyright (C) 2009-$(date +%Y) ESSENTIAL KAOS" $DARK

--- a/rpmbuilder-node.spec
+++ b/rpmbuilder-node.spec
@@ -51,7 +51,7 @@
 
 Summary:         Configuration package for rpmbuilder node
 Name:            rpmbuilder-node
-Version:         1.4.3
+Version:         1.5.0
 Release:         0%{?dist}
 License:         Apache License, Version 2.0
 Group:           Development/Tools
@@ -64,7 +64,7 @@ BuildArch:       noarch
 BuildRoot:       %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 Requires:        rpm >= 4.8.0 rpm-build rpmdevtools
-Requires:        kaosv yum-utils
+Requires:        kaosv yum-utils spec-builddep
 Requires:        perfecto >= 2.0 rpmlint
 
 Provides:        %{name} = %{version}-%{release}
@@ -161,6 +161,9 @@ fi
 ################################################################################
 
 %changelog
+* Mon Sep 25 2023 Anton Novojilov <andy@essentialkaos.com> - 1.5.0-0
+- Added spec-builddep to dependencies
+
 * Mon Mar 27 2023 Anton Novojilov <andy@essentialkaos.com> - 1.4.3-0
 - Fixed bug with printing container info in nodeinfo
 

--- a/rpmbuilder.spec
+++ b/rpmbuilder.spec
@@ -19,7 +19,7 @@ Source100:  checksum.sha512
 BuildArch:  noarch
 BuildRoot:  %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
-Requires:   rpm >= 4.8.0 rpm-build rpmdevtools yum-utils
+Requires:   rpm >= 4.8.0 rpm-build rpmdevtools spec-builddep yum-utils
 Requires:   sshpass coreutils gawk tmux
 Requires:   perfecto >= 3.0 rpmlint
 

--- a/rpmbuilder.spec
+++ b/rpmbuilder.spec
@@ -6,7 +6,7 @@
 
 Summary:    RPM package build helper
 Name:       rpmbuilder
-Version:    3.1.1
+Version:    3.2.0
 Release:    0%{?dist}
 License:    Apache License, Version 2.0
 Group:      Development/Tools
@@ -63,6 +63,11 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Mon Sep 25 2023 Anton Novojilov <andy@essentialkaos.com> - 3.2.0-0
+- Use spec-builddep instead of yum-builddep for installing dependencies
+- Added option '--install-latest/-IL' for installing the latest versions of
+  dependencies
+
 * Tue Aug 22 2023 Anton Novojilov <andy@essentialkaos.com> - 3.1.1-0
 - Fixed output of dependencies versions in version info
 


### PR DESCRIPTION
#### New Features
- Use [`spec-builddep`](https://kaos.sh/spec-builddep) instead of `yum-builddep` for installing dependencies
- Added option `--install-latest/-IL` for installing the latest versions of all required dependencies
